### PR TITLE
Fix exit confirmation on iOS and Bengali locale

### DIFF
--- a/lib/screen/English/dashboard2.dart
+++ b/lib/screen/English/dashboard2.dart
@@ -3,6 +3,7 @@ import 'package:adaptive_pop_scope/adaptive_pop_scope.dart';
 import 'package:auto_size_text/auto_size_text.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'dart:io';
 import 'package:get/get.dart';
 import 'package:intl/intl.dart';
 import 'package:http/http.dart' as http;
@@ -154,7 +155,14 @@ class _DashboardState extends State<Dashboard> {
         actionsAlignment: MainAxisAlignment.center,
         actions: [
           TextButton(
-            onPressed: SystemNavigator.pop,
+            onPressed: () {
+              Navigator.of(context).pop(true);
+              if (Platform.isAndroid) {
+                SystemNavigator.pop();
+              } else if (Platform.isIOS) {
+                exit(0);
+              }
+            },
             child: const Text('Yes', style: TextStyle(color: Colors.white)),
           ),
           TextButton(

--- a/lib/screen/localStrings/hindi.dart
+++ b/lib/screen/localStrings/hindi.dart
@@ -9,7 +9,7 @@ class LocalString extends Translations {
   Map<String, Map<String, String>> get keys => {
         'en_US': {},
         'pa_IN': pbi,
-        'bn_In': bengali,
+        'bn_IN': bengali,
         'hi_IN': {
           'Dairy Animal and Climate Change': 'डेरी पशु और जलवायु परिवर्तन',
           'NDRI Climate Services':


### PR DESCRIPTION
## Summary
- handle exit confirmation on iOS
- fix locale key so Bengali translations load

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68787571c0fc8331a041bcc2dfd5c3a9