### PR TITLE
Unify text styling across info screens

### DIFF
--- a/lib/material/app_styles.dart
+++ b/lib/material/app_styles.dart
@@ -1,0 +1,23 @@
+import 'package:flutter/material.dart';
+import 'package:ndri_climate/material/plugin/responsiveUtils.dart';
+
+class AppStyles {
+  AppStyles._();
+
+  static TextStyle get tabTextStyle => TextStyle(
+        fontSize: ResponsiveUtils.wp(4),
+        fontWeight: FontWeight.bold,
+      );
+
+  static TextStyle get sectionTitleStyle => TextStyle(
+        fontSize: ResponsiveUtils.wp(5),
+        fontWeight: FontWeight.bold,
+        color: const Color(0xFF1976D2),
+      );
+
+  static TextStyle get subtitleTextStyle => TextStyle(
+        fontSize: ResponsiveUtils.wp(3.5),
+        fontWeight: FontWeight.w500,
+        color: Colors.black87,
+      );
+}

--- a/lib/screen/English/Feeding_management.dart
+++ b/lib/screen/English/Feeding_management.dart
@@ -8,6 +8,7 @@ import 'package:ndri_climate/material/reusableappbar.dart';
 import 'package:get/get.dart';
 import 'package:ndri_climate/material/tables.dart';
 
+import 'package:ndri_climate/material/app_styles.dart';
 class Feeding_management extends StatefulWidget {
   const Feeding_management({super.key});
 
@@ -19,16 +20,8 @@ class _Feeding_managementState extends State<Feeding_management> {
   final GlobalKey<ScaffoldState> _scaffoldKey = GlobalKey<ScaffoldState>();
 
 
-  final TextStyle _sectionTitleStyle = TextStyle(
-    fontSize: ResponsiveUtils.wp(5),
-    fontWeight: FontWeight.bold,
-    color: const Color(0xFF1976D2),
-  );
-  final TextStyle _subtitleTextStyle = TextStyle(
-    fontSize: ResponsiveUtils.wp(3.5),
-    fontWeight: FontWeight.w500,
-    color: Colors.black87,
-  );
+  final TextStyle _sectionTitleStyle = AppStyles.sectionTitleStyle;
+  final TextStyle _subtitleTextStyle = AppStyles.subtitleTextStyle;
 
   @override
   Widget build(BuildContext context) {

--- a/lib/screen/English/Healthcare.dart
+++ b/lib/screen/English/Healthcare.dart
@@ -7,6 +7,7 @@ import 'package:ndri_climate/material/plugin/responsiveUtils.dart';
 import 'package:ndri_climate/material/reusableappbar.dart';
 import 'package:get/get.dart';
 
+import 'package:ndri_climate/material/app_styles.dart';
 class Healthcare extends StatefulWidget {
   const Healthcare({super.key});
 
@@ -18,20 +19,9 @@ class _HealthcareState extends State<Healthcare> {
   final GlobalKey<ScaffoldState> _scaffoldKey = GlobalKey<ScaffoldState>();
 
   // Common text styles
-  final TextStyle _tabTextStyle = TextStyle(
-    fontSize: ResponsiveUtils.wp(4),
-    fontWeight: FontWeight.bold,
-  );
-  final TextStyle _sectionTitleStyle = TextStyle(
-    fontSize: ResponsiveUtils.wp(5),
-    fontWeight: FontWeight.bold,
-    color: const Color(0xFF1976D2),
-  );
-  final TextStyle _subtitleTextStyle = TextStyle(
-    fontSize: ResponsiveUtils.wp(3.5),
-    fontWeight: FontWeight.w500,
-    color: Colors.black87,
-  );
+  final TextStyle _tabTextStyle = AppStyles.tabTextStyle;
+  final TextStyle _sectionTitleStyle = AppStyles.sectionTitleStyle;
+  final TextStyle _subtitleTextStyle = AppStyles.subtitleTextStyle;
 
   @override
   Widget build(BuildContext context) {

--- a/lib/screen/English/Thermal_stress.dart
+++ b/lib/screen/English/Thermal_stress.dart
@@ -6,6 +6,7 @@ import 'package:ndri_climate/material/custom_drawer.dart';
 import 'package:ndri_climate/material/plugin/responsiveUtils.dart';
 import 'package:ndri_climate/material/reusableappbar.dart';
 
+import 'package:ndri_climate/material/app_styles.dart';
 class Thermal_Stress extends StatefulWidget {
   const Thermal_Stress({super.key});
 
@@ -17,20 +18,9 @@ class _Thermal_StressState extends State<Thermal_Stress> {
   final GlobalKey<ScaffoldState> _scaffoldKey = GlobalKey<ScaffoldState>();
 
   // Common text styles
-  final TextStyle _tabTextStyle = TextStyle(
-    fontSize: ResponsiveUtils.wp(4),
-    fontWeight: FontWeight.bold,
-  );
-  final TextStyle _sectionTitleStyle = TextStyle(
-    fontSize: ResponsiveUtils.wp(5),
-    fontWeight: FontWeight.bold,
-    color: const Color(0xFF1976D2),
-  );
-  final TextStyle _subtitleTextStyle = TextStyle(
-    fontSize: ResponsiveUtils.wp(3.5),
-    fontWeight: FontWeight.w500,
-    color: Colors.black87,
-  );
+  final TextStyle _tabTextStyle = AppStyles.tabTextStyle;
+  final TextStyle _sectionTitleStyle = AppStyles.sectionTitleStyle;
+  final TextStyle _subtitleTextStyle = AppStyles.subtitleTextStyle;
 
   @override
   Widget build(BuildContext context) {

--- a/lib/screen/English/managemental_practices.dart
+++ b/lib/screen/English/managemental_practices.dart
@@ -6,6 +6,7 @@ import 'package:ndri_climate/material/custom_drawer.dart';
 import 'package:ndri_climate/material/plugin/responsiveUtils.dart';
 import 'package:ndri_climate/material/reusableappbar.dart';
 import 'package:get/get.dart';
+import 'package:ndri_climate/material/app_styles.dart';
 
 class Managemental extends StatefulWidget {
   const Managemental({super.key});
@@ -18,20 +19,9 @@ class _ManagementalState extends State<Managemental> {
   final GlobalKey<ScaffoldState> _scaffoldKey = GlobalKey<ScaffoldState>();
 
   // Common text styles
-  final TextStyle _tabTextStyle = TextStyle(
-    fontSize: ResponsiveUtils.wp(3),
-    fontWeight: FontWeight.bold,
-  );
-  final TextStyle _sectionTitleStyle = TextStyle(
-    fontSize: ResponsiveUtils.wp(4),
-    fontWeight: FontWeight.bold,
-    color: const Color(0xFF1976D2),
-  );
-  final TextStyle _subtitleTextStyle = TextStyle(
-    fontSize: ResponsiveUtils.wp(3),
-    fontWeight: FontWeight.w500,
-    color: Colors.black87,
-  );
+  final TextStyle _tabTextStyle = AppStyles.tabTextStyle;
+  final TextStyle _sectionTitleStyle = AppStyles.sectionTitleStyle;
+  final TextStyle _subtitleTextStyle = AppStyles.subtitleTextStyle;
 
   @override
   Widget build(BuildContext context) {


### PR DESCRIPTION
## Summary
- add `AppStyles` helper for shared TextStyle definitions
- use `AppStyles` in Healthcare, Feeding Management, Management Practices and Thermal Stress screens

## Testing
- `flutter analyze` *(fails: command not found)*
- `dart analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687e0eb564108331968d3d43362845ec