### PR TITLE
Add loaders for network images

### DIFF
--- a/lib/material/custom_drawer.dart
+++ b/lib/material/custom_drawer.dart
@@ -12,6 +12,7 @@ import 'package:ndri_climate/screen/English/aboutndri.dart';
 import 'package:ndri_climate/screen/English/dashboard2.dart';
 import 'package:ndri_climate/screen/English/managemental_practices.dart';
 import 'package:shared_preferences/shared_preferences.dart';
+import 'network_icon.dart';
 
 class CustomDrawer extends StatefulWidget {
   @override
@@ -150,10 +151,10 @@ class _CustomDrawerState extends State<CustomDrawer> {
             },
           ),
           _buildDrawerItem(
-            icon: ImageIcon(
-              NetworkImage('https://cdn-icons-png.flaticon.com/128/16686/16686199.png'),
+            icon: NetworkIcon(
+              url: 'https://cdn-icons-png.flaticon.com/128/16686/16686199.png',
               size: ResponsiveUtils.wp(6),
-              color: Color(0xFF2C96D2),
+              color: const Color(0xFF2C96D2),
             ),
             title: 'Feeding Management'.tr,
             onTap: () {
@@ -164,10 +165,10 @@ class _CustomDrawerState extends State<CustomDrawer> {
             },
           ),
           _buildDrawerItem(
-            icon: ImageIcon(
-              NetworkImage('https://cdn-icons-png.flaticon.com/128/16924/16924841.png'),
+            icon: NetworkIcon(
+              url: 'https://cdn-icons-png.flaticon.com/128/16924/16924841.png',
               size: ResponsiveUtils.wp(6),
-              color: Color(0xFF2C96D2),
+              color: const Color(0xFF2C96D2),
             ),
             title: 'Health Care Management'.tr,
             onTap: () {
@@ -178,10 +179,10 @@ class _CustomDrawerState extends State<CustomDrawer> {
             },
           ),
           _buildDrawerItem(
-            icon: ImageIcon(
-              NetworkImage('https://cdn-icons-png.flaticon.com/128/7521/7521598.png'),
+            icon: NetworkIcon(
+              url: 'https://cdn-icons-png.flaticon.com/128/7521/7521598.png',
               size: ResponsiveUtils.wp(6),
-              color: Color(0xFF2C96D2),
+              color: const Color(0xFF2C96D2),
             ),
             title: 'Management Practices'.tr,
             onTap: () {
@@ -192,10 +193,10 @@ class _CustomDrawerState extends State<CustomDrawer> {
             },
           ),
           _buildDrawerItem(
-            icon: ImageIcon(
-              NetworkImage('https://cdn-icons-png.flaticon.com/128/10414/10414431.png'),
+            icon: NetworkIcon(
+              url: 'https://cdn-icons-png.flaticon.com/128/10414/10414431.png',
               size: ResponsiveUtils.wp(6),
-              color: Color(0xFF2C96D2),
+              color: const Color(0xFF2C96D2),
             ),
             title: 'Thermal Stress Management'.tr,
             onTap: () {
@@ -206,10 +207,10 @@ class _CustomDrawerState extends State<CustomDrawer> {
             },
           ),
           _buildDrawerItem(
-            icon: ImageIcon(
-              NetworkImage('https://cdn-icons-png.flaticon.com/128/17276/17276633.png'),
+            icon: NetworkIcon(
+              url: 'https://cdn-icons-png.flaticon.com/128/17276/17276633.png',
               size: ResponsiveUtils.wp(6),
-              color: Color(0xFF2C96D2),
+              color: const Color(0xFF2C96D2),
             ),
             title: 'Feedback'.tr,
             onTap: () {

--- a/lib/material/network_icon.dart
+++ b/lib/material/network_icon.dart
@@ -1,0 +1,26 @@
+import 'package:flutter/material.dart';
+import 'network_image_loader.dart';
+
+class NetworkIcon extends StatelessWidget {
+  final String url;
+  final double size;
+  final Color? color;
+
+  const NetworkIcon({
+    Key? key,
+    required this.url,
+    required this.size,
+    this.color,
+  }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return NetworkImageLoader(
+      url: url,
+      width: size,
+      height: size,
+      fit: BoxFit.contain,
+      color: color,
+    );
+  }
+}

--- a/lib/material/network_image_loader.dart
+++ b/lib/material/network_image_loader.dart
@@ -1,0 +1,48 @@
+import 'package:flutter/material.dart';
+
+class NetworkImageLoader extends StatelessWidget {
+  final String url;
+  final double? width;
+  final double? height;
+  final BoxFit? fit;
+  final Color? color;
+
+  const NetworkImageLoader({
+    Key? key,
+    required this.url,
+    this.width,
+    this.height,
+    this.fit,
+    this.color,
+  }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Image.network(
+      url,
+      width: width,
+      height: height,
+      fit: fit,
+      color: color,
+      loadingBuilder: (context, child, loadingProgress) {
+        if (loadingProgress == null) return child;
+        return SizedBox(
+          width: width,
+          height: height,
+          child: Center(
+            child: SizedBox(
+              width: (width ?? 24) * 0.5,
+              height: (height ?? 24) * 0.5,
+              child: const CircularProgressIndicator(strokeWidth: 2),
+            ),
+          ),
+        );
+      },
+      errorBuilder: (context, error, stackTrace) => SizedBox(
+        width: width,
+        height: height,
+        child: const Icon(Icons.broken_image),
+      ),
+    );
+  }
+}

--- a/lib/screen/English/daily_forecast.dart
+++ b/lib/screen/English/daily_forecast.dart
@@ -7,6 +7,7 @@ import 'package:ndri_climate/material/custom_drawer.dart';
 import 'package:ndri_climate/material/plugin/responsiveUtils.dart';
 import 'package:ndri_climate/material/reusableappbar.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
+import 'package:ndri_climate/material/network_image_loader.dart';
 
 class Daily_Forecast extends StatefulWidget {
   final String district;
@@ -99,8 +100,8 @@ class _Daily_ForecastState extends State<Daily_Forecast> {
         Row(
           mainAxisAlignment: MainAxisAlignment.spaceBetween,
           children: [
-            Image.network(
-              'https://cdn-icons-png.flaticon.com/128/2469/2469994.png',
+            NetworkImageLoader(
+              url: 'https://cdn-icons-png.flaticon.com/128/2469/2469994.png',
               width: 70.w,
               height: 65.h,
               fit: BoxFit.contain,
@@ -140,7 +141,7 @@ class _Daily_ForecastState extends State<Daily_Forecast> {
     child: Column(
       mainAxisAlignment: MainAxisAlignment.center,
       children: [
-        Image.network(img, width: 35.w, height: 30.h, fit: BoxFit.contain),
+        NetworkImageLoader(url: img, width: 35.w, height: 30.h, fit: BoxFit.contain),
         SizedBox(height: 7.h),
         Text('$val $unit', style: TextStyle(fontSize: 14.sp, fontWeight: FontWeight.w500))
       ],


### PR DESCRIPTION
## Summary
- add reusable `NetworkImageLoader` widget
- add `NetworkIcon` for drawer icons
- use loaders for all network images

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687e16d6136c8331a6c961774c882eaf