### PR TITLE
Fix bottom sheet setState after disposal

### DIFF
--- a/lib/screen/English/PastAdvisories.dart
+++ b/lib/screen/English/PastAdvisories.dart
@@ -120,7 +120,7 @@ class _Past_AdvisoriesState extends State<Past_Advisories> {
       isScrollControlled: true,
       builder: (BuildContext ctx) {
         return StatefulBuilder(
-          builder: (context, setModalState) {
+          builder: (context, _) {
             return SizedBox(
               height: MediaQuery.of(context).size.height * 0.75,
               child: Column(
@@ -168,15 +168,11 @@ class _Past_AdvisoriesState extends State<Past_Advisories> {
                           isScrollControlled: true,
                           builder: (_) => StateBottomSheet(
                             selected_state: (state) {
-                              setModalState(() {
-                                _stateController.text = state;
-                              });
+                              _stateController.text = state;
                             },
                             onStateSelected: (state, districtList) {
-                              setModalState(() {
-                                _stateController.text = state;
-                                _districtController.clear();
-                              });
+                              _stateController.text = state;
+                              _districtController.clear();
                               Navigator.pop(_, state);
                             },
                           ),
@@ -191,17 +187,13 @@ class _Past_AdvisoriesState extends State<Past_Advisories> {
                               isScrollControlled: true,
                               builder: (_) => DistrictBottomSheet(
                                 selected_district: (district) {
-                                  setModalState(() {
-                                    _districtController.text = district;
-                                  });
+                                  _districtController.text = district;
                                 },
                                 districts: districtsList,
                               ),
                             );
                             if (chosenDistrict != null) {
-                              setModalState(() {
-                                _districtController.text = chosenDistrict;
-                              });
+                              _districtController.text = chosenDistrict;
                             }
                           }
                         }
@@ -240,17 +232,13 @@ class _Past_AdvisoriesState extends State<Past_Advisories> {
                             isScrollControlled: true,
                             builder: (_) => DistrictBottomSheet(
                               selected_district: (district) {
-                                setModalState(() {
-                                  _districtController.text = district;
-                                });
+                                _districtController.text = district;
                               },
                               districts: districtsList,
                             ),
                           );
                           if (chosenDistrict != null) {
-                            setModalState(() {
-                              _districtController.text = chosenDistrict;
-                            });
+                            _districtController.text = chosenDistrict;
                           }
                         }
                       },


### PR DESCRIPTION
## Summary
- avoid calling setState on a dismissed bottom sheet by updating the controllers directly

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687e26c740648331bb8dee0af6376ff2