### PR TITLE
Improve dashboard card layout

### DIFF
--- a/lib/apiservices/api_provider.dart
+++ b/lib/apiservices/api_provider.dart
@@ -130,6 +130,22 @@ class ApiProvider {
     }
   }
 
+  /// Fetch past advisories for a state and district
+  Future<List<Advisory>> fetchPastAdvisory({
+    required String state,
+    required String district,
+  }) async {
+    final encS = Uri.encodeComponent(state);
+    final encD = Uri.encodeComponent(district);
+    final url = Uri.parse('$headUrl/api/past-advisories/$encS/$encD');
+    final resp = await http.get(url);
+    if (resp.statusCode == 200) {
+      final list = json.decode(resp.body) as List;
+      return list.map((e) => Advisory.fromJson(e)).toList();
+    }
+    return [];
+  }
+
   Future<List<dynamic>> getStates() async {
     final url = Uri.parse('https://cdn-api.co-vin.in/api/v2/admin/location/states');
     final resp = await http.get(url, headers: {'Accept': 'application/json'});

--- a/lib/screen/English/PastAdvisories.dart
+++ b/lib/screen/English/PastAdvisories.dart
@@ -88,14 +88,14 @@ class _Past_AdvisoriesState extends State<Past_Advisories> {
     });
 
     try {
-      // Now passing both state and district to the API:
-      final response = await ApiProvider().fetchAdvisory(
+      // Fetch past advisories for the selected state and district
+      final response = await ApiProvider().fetchPastAdvisory(
         state: selectedState,
         district: selectedDistrict,
       );
-      allData = response;
 
-      // Filter advisories that exactly match firstDate and secondDate
+      allData = response;
+      // Show all advisories when none match the selected dates
       List<Advisory> currentWeekAdvisories = allData.where((advisory) {
         final from = formatDate(inputDate: advisory.fromDate.toString());
         final to = formatDate(inputDate: advisory.toDate.toString());
@@ -103,7 +103,9 @@ class _Past_AdvisoriesState extends State<Past_Advisories> {
       }).toList();
 
       setState(() {
-        advisoryData = currentWeekAdvisories;
+        advisoryData = currentWeekAdvisories.isNotEmpty
+            ? currentWeekAdvisories
+            : allData;
         isLoading = false;
       });
     } catch (error) {

--- a/lib/screen/English/dashboard2.dart
+++ b/lib/screen/English/dashboard2.dart
@@ -236,7 +236,7 @@ class _DashboardState extends State<Dashboard> {
               ),
               const SizedBox(height: 10),
               SizedBox(
-                height: ResponsiveUtils.hp(18),
+                height: ResponsiveUtils.hp(16),
                 child: PageView(
                   controller: _pageController,
                   onPageChanged: (i) => setState(() => _currentPage = i),
@@ -320,7 +320,7 @@ class _DashboardState extends State<Dashboard> {
                     ),
                   ),
                   child: Container(
-                    height: ResponsiveUtils.hp(18),
+                    height: ResponsiveUtils.hp(16),
                     decoration: BoxDecoration(
                       borderRadius: BorderRadius.circular(16),
                       image:  DecorationImage(
@@ -628,7 +628,7 @@ class _DashboardState extends State<Dashboard> {
     return Container(
       margin: const EdgeInsets.only(left: 10),
       width: ResponsiveUtils.wp(40),
-      height: ResponsiveUtils.hp(18),
+      height: ResponsiveUtils.hp(16),
       decoration: BoxDecoration(
         border: Border.all(width: 1, color: const Color(0xFFABABAB)),
         borderRadius: BorderRadius.circular(10),
@@ -636,7 +636,7 @@ class _DashboardState extends State<Dashboard> {
           image: AssetImage(asset),
           fit: BoxFit.cover,
           colorFilter: ColorFilter.mode(
-            Colors.black.withOpacity(0.45),
+            Colors.black.withOpacity(0.6),
             BlendMode.dstATop,
           ),
         ),
@@ -653,24 +653,43 @@ class _DashboardState extends State<Dashboard> {
         child: InkWell(
           borderRadius: BorderRadius.circular(10),
           onTap: onTap,
-          child: Center(
-            child: AutoSizeText(
-              title.tr,
-              style: TextStyle(
-                fontSize: ResponsiveUtils.wp(3),
-                fontWeight: FontWeight.w700,
-                color: Colors.white,
-                shadows: [
-                  Shadow(
-                    color: Colors.black54,
-                    blurRadius: 4,
-                    offset: Offset(0, 1),
+          child: Stack(
+            children: [
+              Positioned.fill(
+                child: Container(
+                  decoration: BoxDecoration(
+                    borderRadius: BorderRadius.circular(10),
+                    gradient: LinearGradient(
+                      colors: [
+                        Colors.black.withOpacity(0.5),
+                        Colors.transparent,
+                      ],
+                      begin: Alignment.bottomCenter,
+                      end: Alignment.topCenter,
+                    ),
                   ),
-                ],
+                ),
               ),
-              maxLines: 2,
-              textAlign: TextAlign.center,
-            ),
+              Center(
+                child: AutoSizeText(
+                  title.tr,
+                  style: TextStyle(
+                    fontSize: ResponsiveUtils.wp(3),
+                    fontWeight: FontWeight.w700,
+                    color: Colors.white,
+                    shadows: [
+                      Shadow(
+                        color: Colors.black54,
+                        blurRadius: 4,
+                        offset: Offset(0, 1),
+                      ),
+                    ],
+                  ),
+                  maxLines: 2,
+                  textAlign: TextAlign.center,
+                ),
+              ),
+            ],
           ),
         ),
       ),


### PR DESCRIPTION
## Summary
- reduce height of the dashboard `PageView` cards
- darken card images with gradient overlay for text readability
- add `fetchPastAdvisory` API call and use it in Past Advisories screen
- show all advisories when none match the selected dates

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68886b184a808331b5a64386fecebc8c