### PR TITLE
Fix responsive drawer

### DIFF
--- a/lib/material/custom_drawer.dart
+++ b/lib/material/custom_drawer.dart
@@ -49,6 +49,9 @@ class _CustomDrawerState extends State<CustomDrawer> {
 
   @override
   Widget build(BuildContext context) {
+    // Initialize responsive metrics with the current context to ensure
+    // the drawer adapts correctly on different screen sizes
+    ResponsiveUtils().init(context);
     final sidePadding = ResponsiveUtils.wp(3);
 
     return Drawer(

--- a/lib/screen/English/dashboard2.dart
+++ b/lib/screen/English/dashboard2.dart
@@ -201,6 +201,8 @@ class _DashboardState extends State<Dashboard> {
 
   @override
   Widget build(BuildContext context) {
+    // Refresh responsive values for the current screen dimensions
+    ResponsiveUtils().init(context);
     return AdaptivePopScope(
       onWillPop: _confirmExit,
       child: Scaffold(
@@ -872,6 +874,8 @@ class _Dialogue_pageState extends State<Dialogue_page> {
 
   @override
   Widget build(BuildContext context) {
+    // Ensure responsive dimensions are updated for the dialog
+    ResponsiveUtils().init(context);
     return AlertDialog(
       title: Text(
         'Select Location & Language'.tr,


### PR DESCRIPTION
## Summary
- init ResponsiveUtils in the drawer, dashboard, and dialog screens
- ensures drawer sizes update on tablets and larger devices

## Testing
- `dart --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688c3ef03bc88331a97ee964930933bf