### PR TITLE
Use API dates in ClimateServices

### DIFF
--- a/lib/material/custom_drawer.dart
+++ b/lib/material/custom_drawer.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
-import 'package:intl/intl.dart';
 import 'package:ndri_climate/auth/register_screen.dart';
 import 'package:ndri_climate/material/plugin/responsiveUtils.dart';
 import 'package:ndri_climate/screen/English/Climate_Services.dart';
@@ -23,8 +22,6 @@ class _CustomDrawerState extends State<CustomDrawer> {
   String? district = '';
   String? state = '';
   String? language = '';
-  DateTime selectedDate1 = DateTime.now();
-  DateTime selectedDate2 = DateTime.now().add(Duration(days: 7));
 
   @override
   void initState() {
@@ -143,11 +140,10 @@ class _CustomDrawerState extends State<CustomDrawer> {
                 context,
                 MaterialPageRoute(
                   builder: (context) => ClimateServices(
-                    date1: '${DateFormat('dd-MM-yyyy').format(selectedDate1)} - ',
-                    date2: '${DateFormat('dd-MM-yyyy').format(selectedDate2)}',
                     initialDistrict: district.toString(),
                     title: 'Climate Services'.tr,
-                    initialLanguage: language!, initialState: state.toString(),
+                    initialLanguage: language!,
+                    initialState: state.toString(),
                   ),
                 ),
               );

--- a/lib/screen/English/Climate_Services.dart
+++ b/lib/screen/English/Climate_Services.dart
@@ -7,10 +7,9 @@ import 'package:ndri_climate/material/reusableappbar.dart';
 import 'package:get/get.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
+import 'package:intl/intl.dart';
 
 class ClimateServices extends StatefulWidget {
-  final String date1;
-  final String date2;
   final String initialState;
   final String initialDistrict;
   final String initialLanguage;
@@ -18,8 +17,6 @@ class ClimateServices extends StatefulWidget {
 
   const ClimateServices({
     Key? key,
-    required this.date1,
-    required this.date2,
     required this.initialState,
     required this.initialDistrict,
     required this.title,
@@ -32,8 +29,8 @@ class ClimateServices extends StatefulWidget {
 
 class _ClimateServicesState extends State<ClimateServices> {
   final GlobalKey<ScaffoldState> _scaffoldKey = GlobalKey<ScaffoldState>();
-  late String firstDate;
-  late String secondDate;
+  String firstDate = '';
+  String secondDate = '';
   late String state;
   late String district;
   late String language;
@@ -44,8 +41,6 @@ class _ClimateServicesState extends State<ClimateServices> {
   @override
   void initState() {
     super.initState();
-    firstDate = widget.date1.trim();
-    secondDate = widget.date2.trim();
     state = widget.initialState.trim();
     district = widget.initialDistrict.trim();
     language = widget.initialLanguage;
@@ -71,6 +66,10 @@ class _ClimateServicesState extends State<ClimateServices> {
       );
       setState(() {
         advisoryData = data.reversed.toList();
+        if (advisoryData.isNotEmpty) {
+          firstDate = DateFormat('yyyy-MM-dd').format(advisoryData.first.fromDate);
+          secondDate = DateFormat('yyyy-MM-dd').format(advisoryData.first.toDate);
+        }
         isLoading = false;
       });
     } catch (_) {

--- a/lib/screen/English/dashboard2.dart
+++ b/lib/screen/English/dashboard2.dart
@@ -253,14 +253,12 @@ class _DashboardState extends State<Dashboard> {
                           () => Navigator.push(
                         context,
                         MaterialPageRoute(
-                          builder: (_) => ClimateServices(
-                            date1:
-                            '${DateFormat('dd-MM-yyyy').format(_startDate)} - ',
-                            date2: DateFormat('dd-MM-yyyy').format(_endDate),
-                            initialDistrict: _currentDist,
-                            title: 'Climate Advisory'.tr,
-                            initialLanguage: _currentLang, initialState: _currentState,
-                          ),
+                            builder: (_) => ClimateServices(
+                              initialDistrict: _currentDist,
+                              title: 'Climate Advisory'.tr,
+                              initialLanguage: _currentLang,
+                              initialState: _currentState,
+                            ),
                         ),
                       ),
                     ),


### PR DESCRIPTION
## Summary
- remove manual date1/date2 parameters in ClimateServices
- derive date range from advisory API response
- update drawer and dashboard to call ClimateServices without date args

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689b138f35948331a1f500d9382cb1be